### PR TITLE
Fix typo

### DIFF
--- a/lib/etop/report.ex
+++ b/lib/etop/report.ex
@@ -409,7 +409,7 @@ defmodule Etop.Report do
   defp format_fun(_), do: ""
 
   defp name_or_initial_fun(reds, l2) do
-    reds[:registerd_name]
+    reds[:registered_name]
     |> case do
       nil -> format_fun(dict_initial_call(reds) || reds[:initial_call])
       name when is_atom(name) -> name


### PR DESCRIPTION
`Ecto.start` always shows `$initial_call` when reporting because of this typo.
Example:
![image](https://user-images.githubusercontent.com/31795/137441440-487c7967-2459-4207-9c09-3cf2d85f345d.png)
